### PR TITLE
Expose root handler.

### DIFF
--- a/httpserve.go
+++ b/httpserve.go
@@ -81,6 +81,11 @@ func (s *Serve) Listen(port uint16) (err error) {
 	return s.ListenWithConfig(port, defaultConfig)
 }
 
+// Handler exposes the root HTTP handler.
+func (s *Serve) Handler() http.Handler {
+	return s.g.r
+}
+
 // ListenWithConfig will listen on a given port using the specified configuration
 func (s *Serve) ListenWithConfig(port uint16, c Config) (err error) {
 	s.s = newHTTPServer(s.g.r, port, c)


### PR DESCRIPTION
This needs to be exposed to be used with a custom `http.Server` and `listener`:

```go
	listener, err := a.net.Bind(...)

	// expose internal HTTP router to the net using custom listener
	go http.Serve(listener, a.router.Handler())
```

Where `a.router.Handler()` is an `*httpserve.Router` conforming `http.Handler`.